### PR TITLE
Fix sshfs bug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sshfs"]
+	path = sshfs
+	url = git@github.com:jessfraz/sshfs.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,32 @@ RUN set -ex \
     && go get . \
     && go install .
 
+FROM alpine:latest as sshfs
+RUN apk add -U build-base \
+	coreutils \
+	fuse3-dev \
+	git \
+	glib-dev \
+	meson \
+	ninja \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/
+COPY sshfs /usr/src/sshfs
+WORKDIR /usr/src/sshfs
+RUN mkdir build \
+	&& ( \
+	cd build \
+	&& meson .. \
+	&& ninja \
+	&& ninja install \
+	)
 
-FROM alpine:3.6
-RUN apk add -U sshfs
+FROM alpine:latest
+RUN apk add -U fuse3 glib openssh-client \
+	--repository http://dl-3.alpinelinux.org/alpine/edge/testing/
+RUN ln -snf /usr/bin/fusermount3 /usr/bin/fusermount
 COPY --from=builder /go/bin/cmd-server .
+COPY --from=sshfs /usr/local/bin/sshfs /bin/sshfs
+COPY --from=sshfs /usr/local/sbin/mount.sshfs /sbin/mount.sshfs
+COPY --from=sshfs /usr/local/sbin/mount.fuse.sshfs /sbin/mount.fuse.sshfs
 COPY ./data/id_dev .
 CMD ["/cmd-server"]


### PR DESCRIPTION
sshfs: do two calls to `open_common` one for the create and once for the open.

This PR updates the sshfs code to fix the bug.

Hacky... See forked commit here: https://github.com/jessfraz/sshfs/commit/2f729a27d9b6cd984d80151e1788c2a6933d793e

I opened a PR upstream too but I have no idea if anyone checks that repo: https://github.com/libfuse/sshfs/pull/124